### PR TITLE
Refactor: Change user role field from List to Enum type

### DIFF
--- a/src/main/java/com/project/ecommerce/dto/LoginResponseDto.java
+++ b/src/main/java/com/project/ecommerce/dto/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.project.ecommerce.dto;
 
+import com.project.ecommerce.enums.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,6 @@ import java.util.List;
 public class LoginResponseDto {
     String jwt;
     Long userId;
-    String role;
+    UserRole role;
     String name;
 }

--- a/src/main/java/com/project/ecommerce/entity/User.java
+++ b/src/main/java/com/project/ecommerce/entity/User.java
@@ -1,6 +1,7 @@
 package com.project.ecommerce.entity;
 
 import com.project.ecommerce.enums.AuthProviderType;
+import com.project.ecommerce.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -31,6 +32,9 @@ public class User implements UserDetails {
 
     @Enumerated(EnumType.STRING)
     private AuthProviderType providerType;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/project/ecommerce/enums/UserRole.java
+++ b/src/main/java/com/project/ecommerce/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.project.ecommerce.enums;
+
+public enum UserRole {
+    CUSTOMER,
+    ADMIN
+}

--- a/src/main/java/com/project/ecommerce/security/AuthService.java
+++ b/src/main/java/com/project/ecommerce/security/AuthService.java
@@ -9,6 +9,7 @@ import com.project.ecommerce.dto.SignUpRequestDto;
 import com.project.ecommerce.entity.User;
 import com.project.ecommerce.entity.UserDetails;
 import com.project.ecommerce.enums.AuthProviderType;
+import com.project.ecommerce.enums.UserRole;
 import com.project.ecommerce.exception.GenericException;
 import com.project.ecommerce.repository.UserDetailsRepository;
 import com.project.ecommerce.repository.UserRepository;
@@ -58,15 +59,7 @@ public class AuthService {
         User user = (User) authentication.getPrincipal();
         String token = jwtHelper.generateAccessToken(user);
         UserDetails userDetails = userDetailsRepository.findByUser(user).orElseThrow();
-//        List<String> roles =
-//                user.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
-        List<String> roles = new ArrayList<>(
-                user.getAuthorities().stream()
-                        .map(GrantedAuthority::getAuthority)
-                        .toList()
-        );
-        roles.add("CUSTOMER");
-        return new LoginResponseDto(token, user.getId(), roles.get(0),
+        return new LoginResponseDto(token, user.getId(), user.getRole(),
                 userDetails.getFirstName());
     }
 
@@ -78,6 +71,7 @@ public class AuthService {
         user = userRepository.save(User.builder()
                 .username(signUpRequestDto.getUsername())
                 .password(passwordEncoder.encode(signUpRequestDto.getPassword()))
+                .role(UserRole.CUSTOMER)
                 .providerType(AuthProviderType.EMAIL)
                 .build()
         );
@@ -153,13 +147,7 @@ public class AuthService {
             throw new IllegalArgumentException("User already exists with that email");
         }
         String token = jwtHelper.generateAccessToken(user);
-        List<String> roles = new ArrayList<>(
-                user.getAuthorities().stream()
-                        .map(GrantedAuthority::getAuthority)
-                        .toList()
-        );
-        roles.add("CUSTOMER");
-        LoginResponseDto loginResponseDto = new LoginResponseDto(token, user.getId(), roles.get(0),
+        LoginResponseDto loginResponseDto = new LoginResponseDto(token, user.getId(), user.getRole(),
                 name != null ? name : email.substring(0, email.length() > 15 ? email.length() - 10 :
                         email.length()));
         return ResponseEntity.ok(loginResponseDto);

--- a/src/main/java/com/project/ecommerce/security/JwtAuthFilter.java
+++ b/src/main/java/com/project/ecommerce/security/JwtAuthFilter.java
@@ -1,6 +1,7 @@
 package com.project.ecommerce.security;
 
 import com.project.ecommerce.entity.User;
+import com.project.ecommerce.enums.UserRole;
 import com.project.ecommerce.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 @Slf4j
@@ -36,7 +39,28 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String token = requestTokenHeader.split("Bearer ")[1];
         String username = jwtHelper.getUsernameByToken(token);
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+            String uri = request.getRequestURI();
+            Pattern userPattern = Pattern.compile("/user/(\\d+)/");
+            Matcher userMatcher = userPattern.matcher(uri);
+
+            Pattern adminPattern = Pattern.compile("/admin/");
+            Matcher adminMatcher = adminPattern.matcher(uri);
+
+            if(userMatcher.find()){
+                Long pathUserId = Long.parseLong(userMatcher.group(1));
+                User user = userRepository.findByUsername(username).orElseThrow();
+                if (!user.getId().equals(pathUserId) && user.getRole() != UserRole.ADMIN) {
+                    throw new IOException("You are not authorized to access other users' information");
+                }
+            }
+
             User user = userRepository.findByUsername(username).orElseThrow();
+
+            if(adminMatcher.find() && !(user.getRole()== UserRole.ADMIN)){
+                throw new IOException("You are not authorized to use this API");
+            }
+
             UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
                     new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);

--- a/src/main/java/com/project/ecommerce/security/JwtHelper.java
+++ b/src/main/java/com/project/ecommerce/security/JwtHelper.java
@@ -34,7 +34,7 @@ public class JwtHelper {
 
     public String getUsernameByToken(String token) {
         Claims claims = Jwts.parserBuilder()
-                .setSigningKey(jwtSecretKey)
+                .setSigningKey(getSecretKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/java/com/project/ecommerce/security/WebSecurityConfig.java
+++ b/src/main/java/com/project/ecommerce/security/WebSecurityConfig.java
@@ -28,7 +28,6 @@ public class WebSecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/public/**", "/auth/**").permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
> Updated the User entity to use an Enum for the role field instead of a List, simplifying role management across the application.

> Implemented role-based authorization in the AuthFilter class.

> Introduced the RoleType enum with two user roles: CUSTOMER and ADMIN.